### PR TITLE
Fix bugs when using permalink /%postname%/

### DIFF
--- a/UrlToQueryItem.php
+++ b/UrlToQueryItem.php
@@ -211,13 +211,11 @@ class UrlToQueryItem {
             || preg_match( "#^{$match}#", urldecode( $request_match ), $matches )
         ) {
             $varmatch = NULL;
-            $vm = preg_match( '/pagename=\$matches\[([0-9]+)\]/', $query, $varmatch );
-            if (
-                $this->resolver->isVerbose()
-                && isset( $vm[1] )
-                && ( ! get_page_by_path( $matches[$vm[1]] ) )
-            ) {
-                return;
+            if ( $this->resolver->isVerbose() && preg_match( '/pagename=\$matches\[([0-9]+)\]/', $query, $varmatch ) ) {
+                $page = get_page_by_path( $matches[ $varmatch[1] ] );
+                if ( ! $page ) {
+                    return;
+                }
             }
             $this->matched_rule = $match;
         }


### PR DESCRIPTION
When using permalink /%postname%/
the resolver confuse between page and post.
It always return
```
array(2) {
  ["page"]=>
  string(0) ""
  ["pagename"]=>
  string(31) "request-uri-here"
}
```
even it is a post.
